### PR TITLE
Fix: remove tests that aren't relevant anymore

### DIFF
--- a/test/messageSpec.js
+++ b/test/messageSpec.js
@@ -90,17 +90,6 @@ describe('Plugin messaging', function () {
       }).catch(done)
     })
 
-    it('should reject message with an invalid `account`', function (done) {
-      this.pluginA.sendMessage({
-        ledger: this.prefix,
-        account: 'fail',
-        data: {foo: 'bar'}
-      }).catch((e) => {
-        assert.equal(e.name, 'InvalidFieldsError')
-        done()
-      }).catch(done)
-    })
-
     it('should reject message missing `data`', function (done) {
       this.pluginA.sendMessage({
         ledger: this.prefix,

--- a/test/transferSpec.js
+++ b/test/transferSpec.js
@@ -218,40 +218,4 @@ describe('Plugin transfers (optimistic)', function () {
         }).catch(done)
     })
   })
-
-  describe('replyToTransfer', function (done) {
-    it('should be a function', function () {
-      assert.isFunction(this.pluginA.replyToTransfer)
-    })
-
-    it('should reply to a successful transfer', function (done) {
-      const id = uuid()
-
-      this.pluginB.once('incoming_transfer', (transfer) => {
-        this.pluginA.once('reply', (transfer, message) => {
-          assert.equal(transfer.id, id)
-          done()
-        })
-
-        assert.equal(transfer.id, id)
-        this.pluginB.replyToTransfer(transfer.id, 'hello')
-          .then((result) => {
-            assert.isNotOk(result, 'replyToTransfer should resolve to null')
-          })
-      })
-
-      this.pluginA.sendTransfer(Object.assign({
-        id: id,
-        amount: '1.0',
-      }, transferA)).catch(done)
-    })
-
-    it('should not reply to a successful transfer', function (done) {
-      this.pluginB.replyToTransfer(uuid(), 'hello')
-        .catch((e) => {
-          assert.equal(e.name, 'TransferNotFoundError')
-          done()
-        }).catch(done)
-    })
-  })
 })


### PR DESCRIPTION
`replyToTransfer` has been removed from the LedgerPlugin interface, so it's not needed anymore. The test which uses an 'invalid account' for messaging is not reliable in a trust-line situation where there are only two accounts and there's no need to deliver by name.